### PR TITLE
fix: add allowedDevOrigins to suppress cross-origin warning

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,14 @@ const nextConfig: NextConfig = {
    * Enable standalone output for Docker deployments
    */
   output: 'standalone',
+  /**
+   * Fix cross-origin warning for OpenShift dev environments
+   * Allows requests from OpenShift route domains (*.apps.*.opentlc.com)
+   */
+  allowedDevOrigins: [
+    '.apps.ocp.4rhc9.sandbox2233.opentlc.com',
+    '.apps.*.opentlc.com',
+  ],
 };
 
 export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -18,7 +18,6 @@ const nextConfig: NextConfig = {
    * Allows requests from OpenShift route domains (*.apps.*.opentlc.com)
    */
   allowedDevOrigins: [
-    '.apps.ocp.4rhc9.sandbox2233.opentlc.com',
     '.apps.*.opentlc.com',
   ],
 };


### PR DESCRIPTION
Fixes the cross-origin warning when accessing the frontend from OpenShift route domains (*.apps.*.opentlc.com)