### PR TITLE
fix: add Suspense boundary for collection page

### DIFF
--- a/app/collection/page.tsx
+++ b/app/collection/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from 'react';
 import Collections from '@/components/collections';
 import Nav from '@/components/nav';
 import { loadVideoMetadata, loadFilterMetadata } from '@/lib/load-metadata';
@@ -11,11 +12,13 @@ export default function CollectionsPage() {
     return (
         <>
             <Nav />
-            <Collections
-                videos={videoMetadata.videos}
-                filters={filterMetadata}
-                askTheGriotEnabled={askTheGriotEnabled}
-            />
+            <Suspense fallback={<div className="min-h-screen flex items-center justify-center">Loading...</div>}>
+                <Collections
+                    videos={videoMetadata.videos}
+                    filters={filterMetadata}
+                    askTheGriotEnabled={askTheGriotEnabled}
+                />
+            </Suspense>
         </>
     );
 }


### PR DESCRIPTION
## Summary

This PR fixes a build error that was occurring when running `npm run build`. The collection page was failing to prerender due to missing Suspense boundary for `useSearchParams()`.

## Issue

The build was failing with:
```
Error occurred prerendering page "/collection". Read more: https://nextjs.org/docs/messages/prerender-error
Export encountered an error on /collection/page: /collection, exiting the build.
```

## Solution

Wrapped the `Collections` component in a `Suspense` boundary in `/app/collection/page.tsx`. This is required when using `useSearchParams()` in a statically generated page, as it needs to handle the async nature of search params during pre-rendering.

## Changes

- Added `Suspense` import from React
- Wrapped `Collections` component with `<Suspense>` boundary
- Added a fallback loading UI for the Suspense boundary

## Testing

- ✅ Build now completes successfully with `npm run build`
- ✅ Collection page renders correctly
- ✅ Direct video links continue to work (e.g., `/collection?video=mE7xK2qR9Ld`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)