### PR TITLE
fix: resolve minimatch ReDoS vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4580,9 +4580,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "typescript": "^5"
   },
   "overrides": {
-    "minimatch": ">=10.2.1",
+    "minimatch": ">=10.2.3",
     "glob": ">=11.0.0"
   }
 }


### PR DESCRIPTION
## Summary

This PR resolves two high severity ReDoS (Regular Expression Denial of Service) vulnerabilities in the minimatch dependency.

## Vulnerabilities Fixed

### High Severity (2)
1. **GHSA-7r86-cg39-jmmj**: minimatch has ReDoS: matchOne() combinatorial backtracking via multiple non-adjacent GLOBSTAR segments
2. **GHSA-23c5-xmqv-rm74**: minimatch ReDoS: nested *() extglobs generate catastrophically backtracking regular expressions

**Vulnerable Range**: 10.0.0 - 10.2.2  
**Fixed In**: 10.2.3+

## Changes

**package.json**
- Updated minimatch override from `>=10.2.1` to `>=10.2.3`

**package-lock.json**
- Updated dependency tree to use minimatch 10.2.3+

## Testing

- ✅ `npm audit --audit-level=high` - 0 vulnerabilities
- ✅ `npm run build` - Build completes successfully
- ✅ All functionality tested and confirmed working

## Security Impact

Both vulnerabilities involved ReDoS attacks that could cause catastrophic backtracking in regular expression processing. Updating to minimatch 10.2.3 eliminates these attack vectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)