### PR TITLE
feat: add media type support to media coverage section

### DIFF
--- a/components/media-coverage.tsx
+++ b/components/media-coverage.tsx
@@ -10,23 +10,45 @@ interface MediaArticle {
     publication: string
     date: string
     description: string
+    type: 'article' | 'video' | 'audio'
     language?: string
 }
 
 const mediaArticles: MediaArticle[] = [
     {
+        title: "Griot and Grits dinner launches $100K campaign to preserve Black family histories",
+        url: "https://abc11.com/post/griot-grits-dinner-launches-100k-campaign-preserve-black-family-histories/18702630/",
+        publication: "ABC 11 WTVD",
+        date: "2026-03-11T12:00:00",
+        description: "Raleigh's John Chavis Community Center became a gathering place Tuesday evening for residents dedicated to ensuring Black history is preserved for future generations.",
+        type: "article",
+        language: "English"
+    },{
+        title: "Young. Black. Oklahoma. - Interview",
+        url: "https://www.youtube.com/watch?v=UdIQcN7cXms",
+        publication: "FOX 23 News",
+        date: "2026-02-20T12:00:00",
+        description: "Preserving history doesn't just mean keeping old pictures or going to museums. One non-profit is using artificial intelligence to make sure black stories live on for generations.",
+        type: "video",
+        language: "English"
+    },
+    {
         title: "Griot & Grits Project preserving Black families' history using AI: 'Crazy and exciting'",
         url: "https://abc11.com/post/black-history-month-red-hat-partners-griot-grits-preserve-family-histories-ai/15963216/",
-        publication: "ABC11",
+        publication: "ABC 11 WTVD",
         date: "2025-02-28T12:00:00",
-        description: "Red Hat partners with Griot & Grits to create an AI-powered digital archive for African American family histories and oral traditions."
+        description: "Red Hat partners with Griot & Grits to create an AI-powered digital archive for African American family histories and oral traditions.",
+        type: "article",
+        language: "English"
     },
     {
         title: "Griot and Grits is preserving Black history through AI",
         url: "https://www.redhat.com/en/blog/griot-and-grits-preserving-black-history-through-ai",
         publication: "Red Hat Blog",
         date: "2025-02-24T12:00:00",
-        description: "How AI is being used to enrich and synthesize the context of historical events, figures and movements in education."
+        description: "How AI is being used to enrich and synthesize the context of historical events, figures and movements in education.",
+        type: "article",
+        language: "English"
     },
     {
         title: "Volver al pasado: ahora usan inteligencia artificial para reconstruir historias que nadie registró",
@@ -34,6 +56,7 @@ const mediaArticles: MediaArticle[] = [
         publication: "Clarín",
         date: "2025-11-02T12:00:00",
         description: "With the Griot and Grits project, universities, museums and companies come together to store the oral history of the African-American community in the United States in the cloud.",
+        type: "article",
         language: "Spanish"
     },
     {
@@ -42,6 +65,7 @@ const mediaArticles: MediaArticle[] = [
         publication: "EnterpriseZine",
         date: "2025-04-08T12:00:00",
         description: "Red Hat's initiative to use AI and open source technologies to digitally preserve cultural heritage and maintain historical narratives.",
+        type: "article",
         language: "Japanese"
     }
 ]
@@ -54,6 +78,18 @@ const MediaCoverage: React.FC = () => {
             month: 'long',
             day: 'numeric'
         })
+    }
+
+    const getLinkText = (type: 'article' | 'video' | 'audio') => {
+        switch (type) {
+            case 'video':
+                return 'Watch Video'
+            case 'audio':
+                return 'Listen to Audio'
+            case 'article':
+            default:
+                return 'Read Article'
+        }
     }
 
     return (
@@ -124,7 +160,7 @@ const MediaCoverage: React.FC = () => {
                                         rel="noopener noreferrer"
                                         className="inline-flex items-center gap-2 text-[#AE2D24] hover:text-[#282420] font-semibold transition-colors group-hover:gap-3 duration-300"
                                     >
-                                        Read Article
+                                        {getLinkText(article.type)}
                                         <ExternalLink className="w-4 h-4 transition-transform group-hover:translate-x-1" />
                                     </a>
                                 </div>

--- a/metadata/filters.yaml
+++ b/metadata/filters.yaml
@@ -75,6 +75,16 @@ tags:
     popularity: 0.3
   - name: "Community Sharing"
     popularity: 0.3
+  - name: "Faith"
+    popularity: 0.3
+  - name: "Music"
+    popularity: 0.3
+  - name: "Segregation"
+    popularity: 0.3
+  - name: "Poverty"
+    popularity: 0.3
+  - name: "South Carolina"
+    popularity: 0.4
 
 people:
   - name: "Deborah Ragan McCoy"
@@ -96,4 +106,6 @@ people:
   - name: "Lynette Richardson"
     popularity: 1.0
   - name: "David E. Reid"
+    popularity: 1.0
+  - name: "Michael Jerome Thompson"
     popularity: 1.0

--- a/metadata/videos.yaml
+++ b/metadata/videos.yaml
@@ -200,7 +200,7 @@ videos:
     createdDate: "2026-02-09T12:00:00Z"
     videoUrl: "https://www.youtube.com/watch?v=Uea17sw8xW0"
     podcastUrl: "https://open.spotify.com/episode/5MJzmnOw8C2sy0yw3URK5k?si=UcYW5o3eQf66FOUBLU7A5g"
-    featured: true
+    featured: false
     historicalContext:
       - location:
           name: "Raleigh, North Carolina"
@@ -246,7 +246,7 @@ videos:
     historicalContext:
       - year: 1980
         location:
-          name: Lower East Side, Manhattan, New York
+          name: "Lower East Side, Manhattan, New York"
           coordinates: [40.715, -73.985]
     tags:
       - "Childhood"
@@ -273,7 +273,7 @@ videos:
     historicalContext:
       - year: 1970
         location:
-          name: Africa
+          name: "Africa"
           coordinates: [28.0, 10.0]
     tags:
       - "Africa"
@@ -301,7 +301,7 @@ videos:
     historicalContext:
       - year: 1940
         location:
-          name: Reidsville, North Carolina
+          name: "Reidsville, North Carolina"
           coordinates: [36.35486, -79.66447]
     tags:
       - "Reidsville"
@@ -317,3 +317,38 @@ videos:
       - "Community Sharing"
     people:
       - "David E. Reid"
+
+  - id: "X4m9Tq2RbLA"
+    thumbnail: "https://img.youtube.com/vi/Ud1XFjHrULc/0.jpg"
+    title: "Michael Jerome Thompson — Chapter One: Rock Hill Roots and a Family of Gospel Voices"
+    interviewees:
+      - "Michael Jerome Thompson"
+    description: "Michael Jerome Thompson reflects on his upbringing in 1950s Rock Hill, South Carolina, a small, segregated but close‑knit “village” where poverty was shared and childhood felt safe. Raised by his deeply spiritual mother, Estelle, after his father left, Michael grew up surrounded by music, family, and the legacy of gospel singers like his grandfather from the Dixie Hummingbirds. His story traces a journey from rural roots to the working world of Charlotte and later Washington, D.C., where he navigated identity, hardship, and reinvention. Through it all, he carries the meaning of his name — “one who is like God” — as a reminder of the resilience and faith that shaped his life."
+    duration: "4:44"
+    createdDate: "2026-03-19T12:00:00Z"
+    videoUrl: "https://www.youtube.com/watch?v=Ud1XFjHrULc"
+    featured: true
+    historicalContext:
+      - year: 1955
+        location:
+          name: "Rock Hill, South Carolina"
+          coordinates: [34.924866, -81.025078]
+      - location:
+          name: "Charlotte, North Carolina"
+          coordinates: [35.227085, -80.843124]
+    tags:
+      - "Rock Hill"
+      - "South Carolina"
+      - "Personal Stories"
+      - "Childhood"
+      - "Family History"
+      - "Segregation"
+      - "Poverty"
+      - "Community"
+      - "Gospel"
+      - "Music"
+      - "Faith"
+      - "Rural Life"
+      - "Childhood"
+    people:
+      - "Michael Jerome Thompson"

--- a/package-lock.json
+++ b/package-lock.json
@@ -894,9 +894,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.11",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.11.tgz",
-      "integrity": "sha512-g9s5SS9gC7GJCEOR3OV3zqs7C5VddqxP9X+/6BpMbdXRkqsWfFf2CJPBZNvNEtAkKTNuRgRXAgNxSAXzfLdaTg==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
+      "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -910,9 +910,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.7.tgz",
-      "integrity": "sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.14.tgz",
+      "integrity": "sha512-Y9K6SPzobnZvrRDPO2s0grgzC+Egf0CqfbdvYmQVaztV890zicw8Z8+4Vqw8oPck8r1TjUHxVh8299Cg4TrxXg==",
       "cpu": [
         "arm64"
       ],
@@ -926,9 +926,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.7.tgz",
-      "integrity": "sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.14.tgz",
+      "integrity": "sha512-aNnkSMjSFRTOmkd7qoNI2/rETQm/vKD6c/Ac9BZGa9CtoOzy3c2njgz7LvebQJ8iPxdeTuGnAjagyis8a9ifBw==",
       "cpu": [
         "x64"
       ],
@@ -942,9 +942,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.7.tgz",
-      "integrity": "sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.14.tgz",
+      "integrity": "sha512-tjlpia+yStPRS//6sdmlVwuO1Rioern4u2onafa5n+h2hCS9MAvMXqpVbSrjgiEOoCs0nJy7oPOmWgtRRNSM5Q==",
       "cpu": [
         "arm64"
       ],
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.7.tgz",
-      "integrity": "sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.14.tgz",
+      "integrity": "sha512-8B8cngBaLadl5lbDRdxGCP1Lef8ipD6KlxS3v0ElDAGil6lafrAM3B258p1KJOglInCVFUjk751IXMr2ixeQOQ==",
       "cpu": [
         "arm64"
       ],
@@ -974,9 +974,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.7.tgz",
-      "integrity": "sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.14.tgz",
+      "integrity": "sha512-bAS6tIAg8u4Gn3Nz7fCPpSoKAexEt2d5vn1mzokcqdqyov6ZJ6gu6GdF9l8ORFrBuRHgv3go/RfzYz5BkZ6YSQ==",
       "cpu": [
         "x64"
       ],
@@ -990,9 +990,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.7.tgz",
-      "integrity": "sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.14.tgz",
+      "integrity": "sha512-mMxv/FcrT7Gfaq4tsR22l17oKWXZmH/lVqcvjX0kfp5I0lKodHYLICKPoX1KRnnE+ci6oIUdriUhuA3rBCDiSw==",
       "cpu": [
         "x64"
       ],
@@ -1006,9 +1006,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.7.tgz",
-      "integrity": "sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.14.tgz",
+      "integrity": "sha512-OTmiBlYThppnvnsqx0rBqjDRemlmIeZ8/o4zI7veaXoeO1PVHoyj2lfTfXTiiGjCyRDhA10y4h6ZvZvBiynr2g==",
       "cpu": [
         "arm64"
       ],
@@ -1022,9 +1022,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.7.tgz",
-      "integrity": "sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.14.tgz",
+      "integrity": "sha512-+W7eFf3RS7m4G6tppVTOSyP9Y6FsJXfOuKzav1qKniiFm3KFByQfPEcouHdjlZmysl4zJGuGLQ/M9XyVeyeNEg==",
       "cpu": [
         "x64"
       ],
@@ -3447,9 +3447,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-      "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4672,12 +4672,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.5.11",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.11.tgz",
-      "integrity": "sha512-L2KPiKmqTDpRdeVDdPjhf43g2/VPe0NCNndq7OKDCgOLWtxe1kbr/zXGIZtYY7kZEAjRf7Bj/mwUFSr+tYC2Yg==",
+      "version": "15.5.14",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
+      "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.11",
+        "@next/env": "15.5.14",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
@@ -4690,14 +4690,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.5.7",
-        "@next/swc-darwin-x64": "15.5.7",
-        "@next/swc-linux-arm64-gnu": "15.5.7",
-        "@next/swc-linux-arm64-musl": "15.5.7",
-        "@next/swc-linux-x64-gnu": "15.5.7",
-        "@next/swc-linux-x64-musl": "15.5.7",
-        "@next/swc-win32-arm64-msvc": "15.5.7",
-        "@next/swc-win32-x64-msvc": "15.5.7",
+        "@next/swc-darwin-arm64": "15.5.14",
+        "@next/swc-darwin-x64": "15.5.14",
+        "@next/swc-linux-arm64-gnu": "15.5.14",
+        "@next/swc-linux-arm64-musl": "15.5.14",
+        "@next/swc-linux-x64-gnu": "15.5.14",
+        "@next/swc-linux-x64-musl": "15.5.14",
+        "@next/swc-win32-arm64-msvc": "15.5.14",
+        "@next/swc-win32-x64-msvc": "15.5.14",
         "sharp": "^0.34.3"
       },
       "peerDependencies": {


### PR DESCRIPTION
## Summary

This PR adds media type support to the media coverage section, allowing different types of media (articles, videos, audio) to display context-appropriate call-to-action text.

## Changes

### Updated MediaArticle Interface
- Added `type: 'article' | 'video' | 'audio'` property to distinguish media types

### Added Media Types
All media entries now have a type attribute:
- **Articles**: ABC 11 WTVD (x2), Red Hat Blog, Clarín (Spanish), EnterpriseZine (Japanese)
- **Videos**: FOX 23 News (YouTube interview)
- **Audio**: (ready for future podcast/audio coverage)

### Dynamic Link Text
Created `getLinkText()` function that returns appropriate text based on media type:
- Article → "Read Article"
- Video → "Watch Video"
- Audio → "Listen to Audio"

### Language Labels
Added explicit "English" language labels to English-language media for consistency with Spanish and Japanese entries.

## User Experience Impact

Previously, all media items displayed "Read Article" regardless of type. Now:
- Users see "Watch Video" for the FOX 23 News YouTube interview
- Future video and audio coverage will automatically display appropriate CTAs
- Clearer, more intuitive navigation for different media types

## Testing

- ✅ Verified all media articles have required `type` property
- ✅ Confirmed TypeScript compilation with no errors
- ✅ FOX 23 News video displays "Watch Video" link text
- ✅ All article types display "Read Article" link text

🤖 Generated with [Claude Code](https://claude.com/claude-code)