### PR TITLE
feat: add volunteers, sponsors/partners home page section, and UI refinements

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import Hero from '@/components/hero'
 import MediaCoverage from '@/components/media-coverage'
 import Nav from '@/components/nav'
 import Services from '@/components/services'
+import SponsorsPartners from '@/components/sponsors-partners'
 import Testimonials from '@/components/testimonials'
 import Works from '@/components/works'
 import { loadVideoMetadata } from '@/lib/load-metadata'
@@ -34,6 +35,7 @@ const page = () => {
             )}
             <MediaCoverage />
             <Testimonials />
+            <SponsorsPartners />
             {/* <FAQ /> */}
             <ContactSection />
         </>

--- a/components/services.tsx
+++ b/components/services.tsx
@@ -30,49 +30,49 @@ interface ServiceCardProps {
 }
 
 const services: Service[] = [
-    {
-        icon: "",
-        title: "Centralized Repository",
-        excerpt: "A unified storage solution for seamless data management and access.",
-        description: `A centralized repository is a single storage location for data, documents, or code. It provides a unified point of access, ensuring
-        consistency and facilitating collaboration across an organization.`
-    },
-    {
-        icon: "",
-        title: "AI Metadata Extraction",
-        excerpt: "Intelligent extraction of metadata to enhance data organization.",
-        description: `AI metadata extraction involves using artificial intelligence to automatically collect and organize metadata from various data sources.
-        This process enhances data management by extracting relevant information such as names, definitions, context, and technical attributes.`
-    },
-    {
-        icon: "",
-        title: "Content Enrichment",
-        excerpt: "Advanced AI techniques for comprehensive content enhancement.",
-        description: `Content enrichment is the process of applying advanced techniques like machine learning and AI to automatically extract meaningful
-        information from documents. It involves creating fully-enriched products with extensive, customer-centric attributes. This process improves
-        searchability, enhances product discovery, and provides valuable insights for better decision-making.`
-    },
-    {
-        icon: "",
-        title: "AI Annotation",
-        excerpt: "Smart labeling system for enhanced machine learning comprehension.",
-        description: `AI annotation is the practice of labeling or tagging data to make it comprehensible for machine learning models. It involves adding
-        metadata or labels to various data types, including images, text, audio, or video.`
-    },
-    {
-        icon: "",
-        title: "Generative AI Enhancement",
-        excerpt: "Cutting-edge AI models for automated process optimization.",
-        description: `Generative AI models can enhance various aspects of data processing, transformation, and analysis. They can automate repetitive tasks,
-        improve decision-making, and boost productivity across industries.`
-    },
-    {
-        icon: "",
-        title: "Searchable Index",
-        excerpt: "Optimized data indexing for efficient information retrieval.",
-        description: `A searchable index is a structured collection of data optimized for quick and efficient information retrieval. It contains searchable
-        content available for indexing, full-text search, vector search, and filtered queries.`
-    },
+    // {
+    //     icon: "",
+    //     title: "Centralized Repository",
+    //     excerpt: "A unified storage solution for seamless data management and access.",
+    //     description: `A centralized repository is a single storage location for data, documents, or code. It provides a unified point of access, ensuring
+    //     consistency and facilitating collaboration across an organization.`
+    // },
+    // {
+    //     icon: "",
+    //     title: "AI Metadata Extraction",
+    //     excerpt: "Intelligent extraction of metadata to enhance data organization.",
+    //     description: `AI metadata extraction involves using artificial intelligence to automatically collect and organize metadata from various data sources.
+    //     This process enhances data management by extracting relevant information such as names, definitions, context, and technical attributes.`
+    // },
+    // {
+    //     icon: "",
+    //     title: "Content Enrichment",
+    //     excerpt: "Advanced AI techniques for comprehensive content enhancement.",
+    //     description: `Content enrichment is the process of applying advanced techniques like machine learning and AI to automatically extract meaningful
+    //     information from documents. It involves creating fully-enriched products with extensive, customer-centric attributes. This process improves
+    //     searchability, enhances product discovery, and provides valuable insights for better decision-making.`
+    // },
+    // {
+    //     icon: "",
+    //     title: "AI Annotation",
+    //     excerpt: "Smart labeling system for enhanced machine learning comprehension.",
+    //     description: `AI annotation is the practice of labeling or tagging data to make it comprehensible for machine learning models. It involves adding
+    //     metadata or labels to various data types, including images, text, audio, or video.`
+    // },
+    // {
+    //     icon: "",
+    //     title: "Generative AI Enhancement",
+    //     excerpt: "Cutting-edge AI models for automated process optimization.",
+    //     description: `Generative AI models can enhance various aspects of data processing, transformation, and analysis. They can automate repetitive tasks,
+    //     improve decision-making, and boost productivity across industries.`
+    // },
+    // {
+    //     icon: "",
+    //     title: "Searchable Index",
+    //     excerpt: "Optimized data indexing for efficient information retrieval.",
+    //     description: `A searchable index is a structured collection of data optimized for quick and efficient information retrieval. It contains searchable
+    //     content available for indexing, full-text search, vector search, and filtered queries.`
+    // },
 ]
 
 const ServiceCard: React.FC<ServiceCardProps> = ({ service, variants }) => {

--- a/components/sponsors-partners.tsx
+++ b/components/sponsors-partners.tsx
@@ -13,13 +13,14 @@ interface LogoCardProps {
 }
 
 const LogoCard = ({ sponsor, width, height, index, sizes }: LogoCardProps) => {
-    const Tag = sponsor.website ? motion.a : motion.div as React.ElementType;
+    const Tag = (sponsor.website ? motion.a : motion.div) as React.ElementType;
+    const anchorProps = sponsor.website
+        ? { href: sponsor.website, target: "_blank", rel: "noopener noreferrer" }
+        : {};
 
     return (
         <Tag
-            href={sponsor.website}
-            target={sponsor.website ? "_blank" : undefined}
-            rel={sponsor.website ? "noopener noreferrer" : undefined}
+            {...anchorProps}
             initial={{ opacity: 0, scale: 0.9 }}
             whileInView={{ opacity: 1, scale: 1 }}
             whileHover={{ scale: 1.05 }}

--- a/components/sponsors-partners.tsx
+++ b/components/sponsors-partners.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import React from 'react';
+import Image from 'next/image';
+import { motion } from 'framer-motion';
+import { goldSponsors, silverSponsors, bronzeSponsors, partners, Sponsor } from '@/lib/sponsors';
+
+const logoCard = (sponsor: Sponsor, width: string, height: string, index: number) => (
+    <motion.a
+        key={sponsor.name}
+        href={sponsor.website}
+        target="_blank"
+        rel="noopener noreferrer"
+        initial={{ opacity: 0, scale: 0.9 }}
+        whileInView={{ opacity: 1, scale: 1 }}
+        whileHover={{ scale: 1.05 }}
+        transition={{ duration: 0.4, delay: index * 0.1 }}
+        viewport={{ once: true }}
+        className="bg-white rounded-lg shadow-lg p-6 flex items-center justify-center"
+    >
+        <div className={`relative ${width} ${height}`}>
+            <Image src={sponsor.logo} alt={sponsor.name} fill className="object-contain" />
+        </div>
+    </motion.a>
+);
+
+const SponsorsPartners = () => {
+    const hasSponsors = goldSponsors.length > 0 || silverSponsors.length > 0 || bronzeSponsors.length > 0;
+    const hasPartners = partners.length > 0;
+
+    return (
+        <section className="py-20 bg-gray-50">
+            <div className="container mx-auto px-6">
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6 }}
+                    viewport={{ once: true }}
+                >
+                    <h2 className="text-4xl font-bold text-center mb-12 text-gray-900">
+                        Thank You to Our Sponsors &amp; Partners
+                    </h2>
+
+                    {goldSponsors.length > 0 && (
+                        <div className="mb-12">
+                            <h3 className="text-2xl font-bold text-center mb-8 text-yellow-600">Gold Sponsors</h3>
+                            <div className="flex flex-wrap justify-center gap-8">
+                                {goldSponsors.map((s, i) => logoCard(s, "w-64", "h-32", i))}
+                            </div>
+                        </div>
+                    )}
+
+                    {silverSponsors.length > 0 && (
+                        <div className="mb-12">
+                            <h3 className="text-2xl font-bold text-center mb-8 text-gray-400">Silver Sponsors</h3>
+                            <div className="flex flex-wrap justify-center gap-8">
+                                {silverSponsors.map((s, i) => logoCard(s, "w-48", "h-24", i))}
+                            </div>
+                        </div>
+                    )}
+
+                    {bronzeSponsors.length > 0 && (
+                        <div className="mb-12">
+                            <h3 className="text-2xl font-bold text-center mb-8 text-orange-600">Bronze Sponsors</h3>
+                            <div className="flex flex-wrap justify-center gap-8">
+                                {bronzeSponsors.map((s, i) => logoCard(s, "w-32", "h-16", i))}
+                            </div>
+                        </div>
+                    )}
+
+                    {hasSponsors && hasPartners && (
+                        <div className="border-t border-gray-200 my-12" />
+                    )}
+
+                    {hasPartners && (
+                        <div className="mb-12">
+                            <h3 className="text-2xl font-bold text-center mb-8 text-gray-600">Our Partners</h3>
+                            <div className="flex flex-wrap justify-center gap-8">
+                                {partners.map((s, i) => logoCard(s, "w-48", "h-24", i))}
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="text-center mt-12">
+                        <a
+                            href="/#contact"
+                            className="inline-block border-2 border-[#AE2D24] text-[#AE2D24] px-8 py-3 rounded-lg font-semibold hover:bg-[#AE2D24] hover:text-white transition-colors duration-200"
+                        >
+                            Interested in sponsoring? Get in touch →
+                        </a>
+                    </div>
+                </motion.div>
+            </div>
+        </section>
+    );
+};
+
+export default SponsorsPartners;

--- a/components/sponsors-partners.tsx
+++ b/components/sponsors-partners.tsx
@@ -1,28 +1,38 @@
 "use client"
 
-import React from 'react';
 import Image from 'next/image';
 import { motion } from 'framer-motion';
 import { goldSponsors, silverSponsors, bronzeSponsors, partners, Sponsor } from '@/lib/sponsors';
 
-const logoCard = (sponsor: Sponsor, width: string, height: string, index: number) => (
-    <motion.a
-        key={sponsor.name}
-        href={sponsor.website}
-        target="_blank"
-        rel="noopener noreferrer"
-        initial={{ opacity: 0, scale: 0.9 }}
-        whileInView={{ opacity: 1, scale: 1 }}
-        whileHover={{ scale: 1.05 }}
-        transition={{ duration: 0.4, delay: index * 0.1 }}
-        viewport={{ once: true }}
-        className="bg-white rounded-lg shadow-lg p-6 flex items-center justify-center"
-    >
-        <div className={`relative ${width} ${height}`}>
-            <Image src={sponsor.logo} alt={sponsor.name} fill className="object-contain" />
-        </div>
-    </motion.a>
-);
+interface LogoCardProps {
+    sponsor: Sponsor;
+    width: string;
+    height: string;
+    index: number;
+    sizes: string;
+}
+
+const LogoCard = ({ sponsor, width, height, index, sizes }: LogoCardProps) => {
+    const Tag = sponsor.website ? motion.a : motion.div as React.ElementType;
+
+    return (
+        <Tag
+            href={sponsor.website}
+            target={sponsor.website ? "_blank" : undefined}
+            rel={sponsor.website ? "noopener noreferrer" : undefined}
+            initial={{ opacity: 0, scale: 0.9 }}
+            whileInView={{ opacity: 1, scale: 1 }}
+            whileHover={{ scale: 1.05 }}
+            transition={{ duration: 0.4, delay: index * 0.1 }}
+            viewport={{ once: true }}
+            className="bg-white rounded-lg shadow-lg p-6 flex items-center justify-center"
+        >
+            <div className={`relative ${width} ${height}`}>
+                <Image src={sponsor.logo} alt={sponsor.name} fill sizes={sizes} className="object-contain" />
+            </div>
+        </Tag>
+    );
+};
 
 const SponsorsPartners = () => {
     const hasSponsors = goldSponsors.length > 0 || silverSponsors.length > 0 || bronzeSponsors.length > 0;
@@ -40,56 +50,64 @@ const SponsorsPartners = () => {
                     <h2 className="text-4xl font-bold text-center mb-12 text-gray-900">
                         Thank You to Our Sponsors &amp; Partners
                     </h2>
-
-                    {goldSponsors.length > 0 && (
-                        <div className="mb-12">
-                            <h3 className="text-2xl font-bold text-center mb-8 text-yellow-600">Gold Sponsors</h3>
-                            <div className="flex flex-wrap justify-center gap-8">
-                                {goldSponsors.map((s, i) => logoCard(s, "w-64", "h-32", i))}
-                            </div>
-                        </div>
-                    )}
-
-                    {silverSponsors.length > 0 && (
-                        <div className="mb-12">
-                            <h3 className="text-2xl font-bold text-center mb-8 text-gray-400">Silver Sponsors</h3>
-                            <div className="flex flex-wrap justify-center gap-8">
-                                {silverSponsors.map((s, i) => logoCard(s, "w-48", "h-24", i))}
-                            </div>
-                        </div>
-                    )}
-
-                    {bronzeSponsors.length > 0 && (
-                        <div className="mb-12">
-                            <h3 className="text-2xl font-bold text-center mb-8 text-orange-600">Bronze Sponsors</h3>
-                            <div className="flex flex-wrap justify-center gap-8">
-                                {bronzeSponsors.map((s, i) => logoCard(s, "w-32", "h-16", i))}
-                            </div>
-                        </div>
-                    )}
-
-                    {hasSponsors && hasPartners && (
-                        <div className="border-t border-gray-200 my-12" />
-                    )}
-
-                    {hasPartners && (
-                        <div className="mb-12">
-                            <h3 className="text-2xl font-bold text-center mb-8 text-gray-600">Our Partners</h3>
-                            <div className="flex flex-wrap justify-center gap-8">
-                                {partners.map((s, i) => logoCard(s, "w-48", "h-24", i))}
-                            </div>
-                        </div>
-                    )}
-
-                    <div className="text-center mt-12">
-                        <a
-                            href="/#contact"
-                            className="inline-block border-2 border-[#AE2D24] text-[#AE2D24] px-8 py-3 rounded-lg font-semibold hover:bg-[#AE2D24] hover:text-white transition-colors duration-200"
-                        >
-                            Interested in sponsoring? Get in touch →
-                        </a>
-                    </div>
                 </motion.div>
+
+                {goldSponsors.length > 0 && (
+                    <div className="mb-12">
+                        <h3 className="text-2xl font-bold text-center mb-8 text-yellow-600">Gold Sponsors</h3>
+                        <div className="flex flex-wrap justify-center gap-8">
+                            {goldSponsors.map((s, i) => (
+                                <LogoCard key={s.name} sponsor={s} width="w-64" height="h-32" index={i} sizes="256px" />
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {silverSponsors.length > 0 && (
+                    <div className="mb-12">
+                        <h3 className="text-2xl font-bold text-center mb-8 text-gray-400">Silver Sponsors</h3>
+                        <div className="flex flex-wrap justify-center gap-8">
+                            {silverSponsors.map((s, i) => (
+                                <LogoCard key={s.name} sponsor={s} width="w-48" height="h-24" index={i} sizes="192px" />
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {bronzeSponsors.length > 0 && (
+                    <div className="mb-12">
+                        <h3 className="text-2xl font-bold text-center mb-8 text-orange-600">Bronze Sponsors</h3>
+                        <div className="flex flex-wrap justify-center gap-8">
+                            {bronzeSponsors.map((s, i) => (
+                                <LogoCard key={s.name} sponsor={s} width="w-32" height="h-16" index={i} sizes="128px" />
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {hasSponsors && hasPartners && (
+                    <div className="border-t border-gray-200 my-12" />
+                )}
+
+                {hasPartners && (
+                    <div className="mb-12">
+                        <h3 className="text-2xl font-bold text-center mb-8 text-gray-600">Our Partners</h3>
+                        <div className="flex flex-wrap justify-center gap-8">
+                            {partners.map((s, i) => (
+                                <LogoCard key={s.name} sponsor={s} width="w-48" height="h-24" index={i} sizes="192px" />
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                <div className="text-center mt-12">
+                    <a
+                        href="#contact"
+                        className="inline-block border-2 border-[#AE2D24] text-[#AE2D24] px-8 py-3 rounded-lg font-semibold hover:bg-[#AE2D24] hover:text-white transition-colors duration-200"
+                    >
+                        Interested in sponsoring? Get in touch →
+                    </a>
+                </div>
             </div>
         </section>
     );

--- a/components/sponsors-partners.tsx
+++ b/components/sponsors-partners.tsx
@@ -2,6 +2,7 @@
 
 import Image from 'next/image';
 import { motion } from 'framer-motion';
+import { ExternalLink } from 'lucide-react';
 import { goldSponsors, silverSponsors, bronzeSponsors, partners, Sponsor } from '@/lib/sponsors';
 
 interface LogoCardProps {
@@ -36,7 +37,6 @@ const LogoCard = ({ sponsor, width, height, index, sizes }: LogoCardProps) => {
 };
 
 const SponsorsPartners = () => {
-    const hasSponsors = goldSponsors.length > 0 || silverSponsors.length > 0 || bronzeSponsors.length > 0;
     const hasPartners = partners.length > 0;
 
     return (
@@ -86,13 +86,9 @@ const SponsorsPartners = () => {
                     </div>
                 )}
 
-                {hasSponsors && hasPartners && (
-                    <div className="border-t border-gray-200 my-12" />
-                )}
-
                 {hasPartners && (
                     <div className="mb-12">
-                        <h3 className="text-2xl font-bold text-center mb-8 text-gray-600">Our Partners</h3>
+                        <h3 className="text-2xl font-bold text-center mb-8 text-gray-600">Partners</h3>
                         <div className="flex flex-wrap justify-center gap-8">
                             {partners.map((s, i) => (
                                 <LogoCard key={s.name} sponsor={s} width="w-48" height="h-24" index={i} sizes="192px" />
@@ -103,10 +99,11 @@ const SponsorsPartners = () => {
 
                 <div className="text-center mt-12">
                     <a
-                        href="#contact"
-                        className="inline-block border-2 border-[#AE2D24] text-[#AE2D24] px-8 py-3 rounded-lg font-semibold hover:bg-[#AE2D24] hover:text-white transition-colors duration-200"
+                        href="mailto:info@griotandgrits.org?subject=Sponsorship%20Inquiry%20%E2%80%94%20Griot%20%26%20Grits&body=Hello%2C%0A%0AI%20am%20interested%20in%20learning%20more%20about%20sponsorship%20opportunities%20with%20Griot%20%26%20Grits.%20Could%20you%20please%20share%20your%20sponsorship%20prospectus%20and%20details%20about%20the%20program%2C%20including%20available%20tiers%20and%20benefits%3F%0A%0AThank%20you%2C"
+                        className="inline-flex items-center gap-2 bg-[#AE2D24] text-white px-6 py-3 rounded-lg font-semibold hover:bg-[#282420] transition-colors"
                     >
-                        Interested in sponsoring? Get in touch →
+                        Interested in Sponsoring? Get in Touch
+                        <ExternalLink className="w-4 h-4" />
                     </a>
                 </div>
             </div>

--- a/components/who-we-are.tsx
+++ b/components/who-we-are.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import Image from 'next/image';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X } from 'lucide-react';
-import { getBioImageUrl, getImageUrl, getLogoUrl } from '@/lib/cdn';
+import { getBioImageUrl, getImageUrl } from '@/lib/cdn';
 
 // LinkedIn SVG component (Simple Icons doesn't include LinkedIn)
 const LinkedInIcon = ({ size = 24 }: { size?: number }) => (
@@ -25,12 +25,6 @@ interface TeamMember {
     photo: string;
     bio: string;
     linkedin?: string;
-}
-
-interface Sponsor {
-    name: string;
-    logo: string;
-    website?: string;
 }
 
 const WhoWeAre = () => {
@@ -117,49 +111,41 @@ and amplifying all perspectives.`
 
     const volunteerMembers: TeamMember[] = [
         {
-            name: "Volunteer Placeholder 1",
-            title: "Storykeeper",
-            photo: getImageUrl("crew2.png"),
-            bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
+            name: "Demethria Ramseur",
+            title: "Community Manager, Story Collection & Digital Archiving",
+            photo: getBioImageUrl("D_Ramseur.jpg"),
+            bio: "Demethria Ramseur is an Agile practitioner and project manager who helps teams work smarter, not harder, guiding cross‑functional groups in improving how they plan, collaborate, and deliver by blending structured project management with adaptive Agile practices. She also serves as a Community Manager for the Griot and Grits initiative, supporting story collection and digital archiving to amplify and preserve community narratives."
         },
         {
-            name: "Volunteer Placeholder 2",
-            title: "Storykeeper",
-            photo: getImageUrl("crew2.png"),
-            bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
+            name: "Thoan Freckleton",
+            title: "Music & Creative Production",
+            photo: getBioImageUrl("T_Freckleton.jpg"),
+            bio: "Thoan Freckleton is a strategist and technologist dedicated to building bridges between systems, strategy, and service. With a professional background spanning technical project management, equity research, and data analytics, he approaches complex challenges as an imaginative \"Questionary\" who prioritizes big-picture impact over the status quo. Thoan focuses on the intersection of innovation and human-centered progress to create a lasting legacy. He operates under the firm belief that technology is only as powerful as the people and processes it empowers, centering his work on culture, community, and equitable growth."
         },
         {
-            name: "Volunteer Placeholder 3",
-            title: "Storykeeper",
-            photo: getImageUrl("crew2.png"),
-            bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
-        }
-    ];
-
-    const goldSponsors: Sponsor[] = [
+            name: "Kimla Lee",
+            title: "Ethical AI, Bias Mitigation & Legal",
+            photo: getBioImageUrl("K_Lee.jpg"),
+            bio: "Kimla Lee is a Data and AI Governance Leader dedicated to advancing ethical AI and equitable technology practices. Her work focuses on bias mitigation, data governance, and responsible data use across systems and organizations. With experience spanning software development, analytics, and compliance, Kimla brings a holistic approach and strategic mindset to solving complex organizational challenges. She is also committed to community outreach, helping students and emerging professionals explore pathways into STEM and data-driven careers, and enabling teams to build trusted AI solutions that align with both business objectives and societal responsibility."
+        },
         {
-            name: "Resilient Ventures",
-            logo: getLogoUrl("RV Color Horizontal.jpg"),
-            website: "https://resilient-ventures.com"
-        }
-    ];
-
-    const silverSponsors: Sponsor[] = [];
-
-    const bronzeSponsors: Sponsor[] = [];
-
-    const partners: Sponsor[] = [
+            name: "Albert Myles",
+            title: "AI Services",
+            photo: getBioImageUrl("A_Myles.jpg"),
+            bio: "Albert is a Knowledge Management Professional with a passion for technology and creativity. As a veteran technologist, Albert thrives at translating technical jargon to business outcomes. Griot and Grits provides a perfect outlet for Albert's Techno-creative energy."
+        },
         {
-            name: "Mass Open Cloud",
-            logo: getLogoUrl("MOCwordmark_RGB_small.png"),
-            website: "https://massopen.cloud"
+            name: "Everett Moore",
+            title: "Videographer",
+            photo: getBioImageUrl("E_Moore.jpg"),
+            bio: "Everette Moore is a digital content creator with a strong foundation in photography and visual storytelling. As the former owner of a photography and digital content company, he has developed a keen eye for capturing compelling narratives through both still and motion media. His work has contributed to major film and photography projects, showcasing his versatility and creative direction.\n\nCurrently, Everette serves as the videographer for Griot and Grits, where he plays a key role in preserving cultural narratives through visual media. As part of this collective effort, he has contributed to the production of over 25 documentaries, helping to amplify voices and document stories that matter. Driven by purpose and creativity, Everette continues to use his skills to inform, inspire, and preserve history through digital storytelling."
         }
     ];
 
     const MemberCard = ({ member, onClick }: { member: TeamMember; onClick: () => void }) => (
         <motion.div
             whileHover={{ scale: 1.05 }}
-            className="bg-white rounded-lg shadow-lg overflow-hidden cursor-pointer"
+            className="bg-white rounded-lg shadow-lg overflow-hidden cursor-pointer w-full"
             onClick={onClick}
         >
             <div className="relative w-full aspect-square">
@@ -271,7 +257,7 @@ and amplifying all perspectives.`
                         viewport={{ once: true }}
                     >
                         <h2 className="text-4xl font-bold text-center mb-12 text-gray-900">Our Team</h2>
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 mb-16 px-20">
+                        <div className="grid grid-cols-2 md:grid-cols-3 gap-6 mb-16 max-w-3xl mx-auto justify-items-center">
                             {teamMembers.map((member) => (
                                 <MemberCard
                                     key={member.name}
@@ -280,104 +266,6 @@ and amplifying all perspectives.`
                                 />
                             ))}
                         </div>
-
-                        {/* Volunteers Section */}
-                        <motion.div
-                            initial={{ opacity: 0, y: 20 }}
-                            whileInView={{ opacity: 1, y: 0 }}
-                            transition={{ duration: 0.6, delay: 0.2 }}
-                            viewport={{ once: true }}
-                            className="mt-12 bg-white rounded-lg shadow-lg overflow-hidden mx-auto max-w-6xl"
-                        >
-                            <div className="p-8">
-                                <h3 className="text-2xl font-bold text-gray-900 mb-4 text-center">Griot & Grits Storykeeping Collective</h3>
-                                <p className="text-gray-700 text-lg leading-relaxed text-center mb-8">
-                                    Many dedicated volunteers who have contributed countless hours to preserving
-                                    and sharing the stories that matter. Their passion and commitment make our mission possible.
-                                </p>
-
-                                {/* Creative collage - grid on desktop, vertical on mobile */}
-                                <div className="flex flex-col md:relative md:w-full md:h-[500px] gap-4 md:gap-0">
-                                    {/* Mobile: vertical stack, Desktop: grid layout */}
-                                    <div className="flex flex-col md:relative md:w-full md:h-full gap-4 md:gap-0">
-                                        {/* First image */}
-                                        <motion.div
-                                            initial={{ opacity: 0, scale: 0.8 }}
-                                            whileInView={{ opacity: 1, scale: 1 }}
-                                            transition={{ duration: 0.5, delay: 0.3 }}
-                                            className="relative w-full h-64 md:absolute md:top-0 md:left-0 md:w-[45%] md:h-[45%] shadow-xl z-10"
-                                        >
-                                            <Image
-                                                src={getImageUrl("2239728647962445031.jpg")}
-                                                alt="Volunteers at work"
-                                                fill
-                                                className="object-cover object-top rounded-lg"
-                                            />
-                                        </motion.div>
-
-                                        {/* Second image */}
-                                        <motion.div
-                                            initial={{ opacity: 0, scale: 0.8 }}
-                                            whileInView={{ opacity: 1, scale: 1 }}
-                                            transition={{ duration: 0.5, delay: 0.4 }}
-                                            className="relative w-full h-64 md:absolute md:top-0 md:right-0 md:w-[45%] md:h-[45%] shadow-xl z-10"
-                                        >
-                                            <Image
-                                                src={getImageUrl("crew2.png")}
-                                                alt="Community engagement"
-                                                fill
-                                                className="object-cover object-top rounded-lg"
-                                            />
-                                        </motion.div>
-
-                                        {/* Third image */}
-                                        <motion.div
-                                            initial={{ opacity: 0, scale: 0.8 }}
-                                            whileInView={{ opacity: 1, scale: 1 }}
-                                            transition={{ duration: 0.5, delay: 0.5 }}
-                                            className="relative w-full h-64 md:absolute md:bottom-0 md:left-0 md:w-[45%] md:h-[45%] shadow-xl z-10"
-                                        >
-                                            <Image
-                                                src={getImageUrl("3797497829222735602.jpg")}
-                                                alt="Storykeeping session"
-                                                fill
-                                                className="object-cover object-top rounded-lg"
-                                            />
-                                        </motion.div>
-
-                                        {/* Fourth image */}
-                                        <motion.div
-                                            initial={{ opacity: 0, scale: 0.8 }}
-                                            whileInView={{ opacity: 1, scale: 1 }}
-                                            transition={{ duration: 0.5, delay: 0.6 }}
-                                            className="relative w-full h-64 md:absolute md:bottom-0 md:right-0 md:w-[45%] md:h-[45%] shadow-xl z-10"
-                                        >
-                                            <Image
-                                                src={getImageUrl("8348915442707023838.jpg")}
-                                                alt="Volunteer team"
-                                                fill
-                                                className="object-cover object-top rounded-lg"
-                                            />
-                                        </motion.div>
-                                    </div>
-                                </div>
-
-                                <div className="mt-12">
-                                    <h3 className="text-2xl font-bold text-center text-gray-900 mb-8">
-                                        Meet the Storykeepers
-                                    </h3>
-                                    <div className="grid grid-cols-2 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
-                                        {volunteerMembers.map((member) => (
-                                            <MemberCard
-                                                key={member.name}
-                                                member={member}
-                                                onClick={() => setSelectedMember(member)}
-                                            />
-                                        ))}
-                                    </div>
-                                </div>
-                            </div>
-                        </motion.div>
                     </motion.div>
                 </div>
             </section>
@@ -407,142 +295,102 @@ and amplifying all perspectives.`
                 </section>
             )}
 
-            {/* Sponsors Section */}
-            {(goldSponsors.length > 0 || silverSponsors.length > 0 || bronzeSponsors.length > 0) && (
-                <section className="py-20 bg-gray-100">
-                    <div className="container mx-auto px-6">
-                        <motion.div
-                            initial={{ opacity: 0, y: 20 }}
-                            whileInView={{ opacity: 1, y: 0 }}
-                            transition={{ duration: 0.6 }}
-                            viewport={{ once: true }}
-                        >
-                            <h2 className="text-4xl font-bold text-center mb-12 text-gray-900">Our Sponsors</h2>
+            {/* Storykeeping Collective Section */}
+            <section className="py-20">
+                <div className="container mx-auto px-6">
+                    <motion.div
+                        initial={{ opacity: 0, y: 20 }}
+                        whileInView={{ opacity: 1, y: 0 }}
+                        transition={{ duration: 0.6 }}
+                        viewport={{ once: true }}
+                        className="bg-white rounded-lg shadow-lg overflow-hidden mx-auto max-w-6xl"
+                    >
+                        <div className="p-8">
+                            <h2 className="text-4xl font-bold text-gray-900 mb-4 text-center">Griot & Grits Storykeeping Collective</h2>
+                            <p className="text-gray-700 text-lg leading-relaxed text-center mb-8">
+                                Many dedicated volunteers who have contributed countless hours to preserving
+                                and sharing the stories that matter. Their passion and commitment make our mission possible.
+                            </p>
 
-                        {/* Gold Sponsors */}
-                        {goldSponsors.length > 0 && (
-                            <div className="mb-16">
-                                <h3 className="text-2xl font-bold text-center mb-8 text-yellow-600">Gold Sponsors</h3>
-                                <div className="flex flex-wrap justify-center gap-12">
-                                    {goldSponsors.map((sponsor) => (
-                                        <motion.a
-                                            key={sponsor.name}
-                                            href={sponsor.website}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            whileHover={{ scale: 1.05 }}
-                                            className="bg-white p-8 rounded-lg shadow-lg"
-                                        >
-                                            <div className="relative w-64 h-32">
-                                                <Image
-                                                    src={sponsor.logo}
-                                                    alt={sponsor.name}
-                                                    fill
-                                                    className="object-contain"
-                                                />
-                                            </div>
-                                        </motion.a>
+                            <div className="mb-12">
+                                <h3 className="text-2xl font-bold text-center text-gray-900 mb-8">
+                                    Meet the Storykeepers
+                                </h3>
+                                <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6 max-w-5xl mx-auto justify-items-center">
+                                    {volunteerMembers.map((member) => (
+                                        <MemberCard
+                                            key={member.name}
+                                            member={member}
+                                            onClick={() => setSelectedMember(member)}
+                                        />
                                     ))}
                                 </div>
                             </div>
-                        )}
 
-                        {/* Silver Sponsors */}
-                        {silverSponsors.length > 0 && (
-                            <div className="mb-16">
-                                <h3 className="text-2xl font-bold text-center mb-8 text-gray-400">Silver Sponsors</h3>
-                                <div className="flex flex-wrap justify-center gap-8">
-                                    {silverSponsors.map((sponsor) => (
-                                        <motion.a
-                                            key={sponsor.name}
-                                            href={sponsor.website}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            whileHover={{ scale: 1.05 }}
-                                            className="bg-white p-6 rounded-lg shadow-lg"
-                                        >
-                                            <div className="relative w-48 h-24">
-                                                <Image
-                                                    src={sponsor.logo}
-                                                    alt={sponsor.name}
-                                                    fill
-                                                    className="object-contain"
-                                                />
-                                            </div>
-                                        </motion.a>
-                                    ))}
-                                </div>
-                            </div>
-                        )}
-
-                        {/* Bronze Sponsors */}
-                        {bronzeSponsors.length > 0 && (
-                            <div>
-                                <h3 className="text-2xl font-bold text-center mb-8 text-orange-600">Bronze Sponsors</h3>
-                                <div className="flex flex-wrap justify-center gap-6">
-                                    {bronzeSponsors.map((sponsor) => (
-                                        <motion.a
-                                            key={sponsor.name}
-                                            href={sponsor.website}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            whileHover={{ scale: 1.05 }}
-                                            className="bg-white p-4 rounded-lg shadow-lg"
-                                        >
-                                            <div className="relative w-32 h-16">
-                                                <Image
-                                                    src={sponsor.logo}
-                                                    alt={sponsor.name}
-                                                    fill
-                                                    className="object-contain"
-                                                />
-                                            </div>
-                                        </motion.a>
-                                    ))}
-                                </div>
-                            </div>
-                        )}
-                        </motion.div>
-                    </div>
-                </section>
-            )}
-
-            {/* Partners Section */}
-            {partners.length > 0 && (
-                <section className="py-20 bg-white">
-                    <div className="container mx-auto px-6">
-                        <motion.div
-                            initial={{ opacity: 0, y: 20 }}
-                            whileInView={{ opacity: 1, y: 0 }}
-                            transition={{ duration: 0.6 }}
-                            viewport={{ once: true }}
-                        >
-                            <h2 className="text-4xl font-bold text-center mb-12 text-gray-900">Our Partners</h2>
-                            <div className="flex flex-wrap justify-center gap-12">
-                                {partners.map((partner) => (
-                                    <motion.a
-                                        key={partner.name}
-                                        href={partner.website}
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        whileHover={{ scale: 1.05 }}
-                                        className="bg-gray-50 p-8 rounded-lg shadow-lg"
+                            {/* Creative collage - grid on desktop, vertical on mobile */}
+                            <div className="flex flex-col md:relative md:w-full md:h-[500px] gap-4 md:gap-0">
+                                <div className="flex flex-col md:relative md:w-full md:h-full gap-4 md:gap-0">
+                                    <motion.div
+                                        initial={{ opacity: 0, scale: 0.8 }}
+                                        whileInView={{ opacity: 1, scale: 1 }}
+                                        transition={{ duration: 0.5, delay: 0.3 }}
+                                        className="relative w-full h-64 md:absolute md:top-0 md:left-0 md:w-[45%] md:h-[45%] shadow-xl z-10"
                                     >
-                                        <div className="relative w-64 h-32">
-                                            <Image
-                                                src={partner.logo}
-                                                alt={partner.name}
-                                                fill
-                                                className="object-contain"
-                                            />
-                                        </div>
-                                    </motion.a>
-                                ))}
+                                        <Image
+                                            src={getImageUrl("2239728647962445031.jpg")}
+                                            alt="Volunteers at work"
+                                            fill
+                                            className="object-cover object-top rounded-lg"
+                                        />
+                                    </motion.div>
+
+                                    <motion.div
+                                        initial={{ opacity: 0, scale: 0.8 }}
+                                        whileInView={{ opacity: 1, scale: 1 }}
+                                        transition={{ duration: 0.5, delay: 0.4 }}
+                                        className="relative w-full h-64 md:absolute md:top-0 md:right-0 md:w-[45%] md:h-[45%] shadow-xl z-10"
+                                    >
+                                        <Image
+                                            src={getImageUrl("crew2.png")}
+                                            alt="Community engagement"
+                                            fill
+                                            className="object-cover object-top rounded-lg"
+                                        />
+                                    </motion.div>
+
+                                    <motion.div
+                                        initial={{ opacity: 0, scale: 0.8 }}
+                                        whileInView={{ opacity: 1, scale: 1 }}
+                                        transition={{ duration: 0.5, delay: 0.5 }}
+                                        className="relative w-full h-64 md:absolute md:bottom-0 md:left-0 md:w-[45%] md:h-[45%] shadow-xl z-10"
+                                    >
+                                        <Image
+                                            src={getImageUrl("3797497829222735602.jpg")}
+                                            alt="Storykeeping session"
+                                            fill
+                                            className="object-cover object-top rounded-lg"
+                                        />
+                                    </motion.div>
+
+                                    <motion.div
+                                        initial={{ opacity: 0, scale: 0.8 }}
+                                        whileInView={{ opacity: 1, scale: 1 }}
+                                        transition={{ duration: 0.5, delay: 0.6 }}
+                                        className="relative w-full h-64 md:absolute md:bottom-0 md:right-0 md:w-[45%] md:h-[45%] shadow-xl z-10"
+                                    >
+                                        <Image
+                                            src={getImageUrl("8348915442707023838.jpg")}
+                                            alt="Volunteer team"
+                                            fill
+                                            className="object-cover object-top rounded-lg"
+                                        />
+                                    </motion.div>
+                                </div>
                             </div>
-                        </motion.div>
-                    </div>
-                </section>
-            )}
+                        </div>
+                    </motion.div>
+                </div>
+            </section>
 
             {/* Bio Modal */}
             {selectedMember && (

--- a/components/who-we-are.tsx
+++ b/components/who-we-are.tsx
@@ -115,6 +115,27 @@ and amplifying all perspectives.`
         }
     ];
 
+    const volunteerMembers: TeamMember[] = [
+        {
+            name: "Volunteer Placeholder 1",
+            title: "Storykeeper",
+            photo: getImageUrl("crew2.png"),
+            bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
+        },
+        {
+            name: "Volunteer Placeholder 2",
+            title: "Storykeeper",
+            photo: getImageUrl("crew2.png"),
+            bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
+        },
+        {
+            name: "Volunteer Placeholder 3",
+            title: "Storykeeper",
+            photo: getImageUrl("crew2.png"),
+            bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
+        }
+    ];
+
     const goldSponsors: Sponsor[] = [
         {
             name: "Resilient Ventures",
@@ -338,6 +359,21 @@ and amplifying all perspectives.`
                                                 className="object-cover object-top rounded-lg"
                                             />
                                         </motion.div>
+                                    </div>
+                                </div>
+
+                                <div className="mt-12">
+                                    <h3 className="text-2xl font-bold text-center text-gray-900 mb-8">
+                                        Meet the Storykeepers
+                                    </h3>
+                                    <div className="grid grid-cols-2 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+                                        {volunteerMembers.map((member) => (
+                                            <MemberCard
+                                                key={member.name}
+                                                member={member}
+                                                onClick={() => setSelectedMember(member)}
+                                            />
+                                        ))}
                                     </div>
                                 </div>
                             </div>

--- a/docs/superpowers/plans/2026-04-27-volunteers-storykeeping-collective.md
+++ b/docs/superpowers/plans/2026-04-27-volunteers-storykeeping-collective.md
@@ -1,0 +1,149 @@
+# Storykeeping Collective Volunteer Listing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a clickable volunteer card grid (3 placeholders) below the Storykeeping Collective photo collage on the Who We Are page.
+
+**Architecture:** Single-file change to `components/who-we-are.tsx`. Add a `volunteerMembers: TeamMember[]` array and render it with the existing `MemberCard` component and `selectedMember`/`BioModal` state — no new components or interfaces needed.
+
+**Tech Stack:** Next.js 15, React, Tailwind CSS, Framer Motion, Playwright (e2e tests)
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Modify | `components/who-we-are.tsx` |
+| Create | `tests/e2e/who-we-are.spec.ts` |
+
+---
+
+### Task 1: Write the failing Playwright test
+
+**Files:**
+- Create: `tests/e2e/who-we-are.spec.ts`
+
+- [ ] **Step 1: Create the test file**
+
+```typescript
+// tests/e2e/who-we-are.spec.ts
+import { test, expect } from '@playwright/test';
+
+test.describe('Who We Are page', () => {
+  test('shows Storykeeping Collective volunteer cards', async ({ page }) => {
+    await page.goto('/who-we-are');
+
+    const section = page.locator('text=Meet the Storykeepers');
+    await expect(section).toBeVisible();
+  });
+
+  test('volunteer card opens bio modal on click', async ({ page }) => {
+    await page.goto('/who-we-are');
+
+    await page.locator('text=Volunteer Placeholder 1').first().click();
+
+    const modal = page.locator('text=A dedicated volunteer');
+    await expect(modal).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm test -- tests/e2e/who-we-are.spec.ts
+```
+
+Expected: Both tests FAIL — "Meet the Storykeepers" heading and volunteer cards don't exist yet.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/e2e/who-we-are.spec.ts
+git commit -m "test: add failing e2e tests for Storykeeping Collective volunteer listing"
+```
+
+---
+
+### Task 2: Add volunteer data and render the card grid
+
+**Files:**
+- Modify: `components/who-we-are.tsx`
+
+- [ ] **Step 1: Add the `volunteerMembers` array**
+
+Inside the `WhoWeAre` component body, directly after the `boardMembers` array (around line 116), add:
+
+```typescript
+const volunteerMembers: TeamMember[] = [
+    {
+        name: "Volunteer Placeholder 1",
+        title: "Storykeeper",
+        photo: getImageUrl("crew2.png"),
+        bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
+    },
+    {
+        name: "Volunteer Placeholder 2",
+        title: "Storykeeper",
+        photo: getImageUrl("crew2.png"),
+        bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
+    },
+    {
+        name: "Volunteer Placeholder 3",
+        title: "Storykeeper",
+        photo: getImageUrl("crew2.png"),
+        bio: "A dedicated volunteer and member of the Griot & Grits Storykeeping Collective. This placeholder will be replaced with the volunteer's full biography and photo when available."
+    }
+];
+```
+
+- [ ] **Step 2: Add the volunteer grid below the collage**
+
+Inside the Storykeeping Collective `<div className="p-8">` block, directly after the closing `</div>` of the collage (the `flex flex-col md:relative md:w-full md:h-[500px]` div, around line 342), add:
+
+```tsx
+<div className="mt-12">
+    <h3 className="text-2xl font-bold text-center text-gray-900 mb-8">
+        Meet the Storykeepers
+    </h3>
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        {volunteerMembers.map((member) => (
+            <MemberCard
+                key={member.name}
+                member={member}
+                onClick={() => setSelectedMember(member)}
+            />
+        ))}
+    </div>
+</div>
+```
+
+- [ ] **Step 3: Run the e2e tests to confirm they pass**
+
+Start the dev server in one terminal:
+```bash
+npm run dev
+```
+
+In another terminal:
+```bash
+npm test -- tests/e2e/who-we-are.spec.ts
+```
+
+Expected: Both tests PASS.
+
+- [ ] **Step 4: Verify visually in the browser**
+
+Open `http://localhost:3000/who-we-are`, scroll to the Storykeeping Collective section, and confirm:
+- "Meet the Storykeepers" heading appears below the 4-photo collage
+- 3 volunteer cards render in a responsive grid (2 columns on mobile, 3 on desktop)
+- Clicking a card opens the bio modal with the placeholder text
+- Closing the modal works correctly
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/who-we-are.tsx
+git commit -m "feat: add Storykeeping Collective volunteer listing with 3 placeholder members"
+```

--- a/docs/superpowers/plans/2026-05-04-sponsors-partners-home-page.md
+++ b/docs/superpowers/plans/2026-05-04-sponsors-partners-home-page.md
@@ -1,0 +1,388 @@
+# Sponsors & Partners Home Page Section Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move sponsors/partners from the Who We Are page to the home page as a styled "thank you" section with tier hierarchy, framer-motion animations, and a "Become a Sponsor" CTA.
+
+**Architecture:** Extract sponsor/partner data into `lib/sponsors.ts`, build a new `components/sponsors-partners.tsx` client component, wire it into `app/page.tsx`, and strip the duplicate sections from `components/who-we-are.tsx`.
+
+**Tech Stack:** Next.js 15, React, Tailwind CSS, Framer Motion, Playwright (e2e tests)
+
+---
+
+## File Map
+
+| Action | Path |
+|--------|------|
+| Create | `lib/sponsors.ts` |
+| Create | `components/sponsors-partners.tsx` |
+| Modify | `app/page.tsx` |
+| Modify | `components/who-we-are.tsx` |
+| Modify | `tests/e2e/home.spec.ts` |
+
+---
+
+### Task 1: Write the failing Playwright test
+
+**Files:**
+- Modify: `tests/e2e/home.spec.ts`
+
+- [ ] **Step 1: Add the failing test to `tests/e2e/home.spec.ts`**
+
+Open `tests/e2e/home.spec.ts` and append these two tests inside the existing `test.describe` block:
+
+```typescript
+  test('shows sponsors and partners section', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('text=Thank You to Our Sponsors & Partners')).toBeVisible();
+  });
+
+  test('shows become a sponsor CTA', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('text=Interested in sponsoring?')).toBeVisible();
+  });
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+npm test -- tests/e2e/home.spec.ts
+```
+
+Expected: the two new tests FAIL — the heading and CTA don't exist on the home page yet.
+
+- [ ] **Step 3: Commit the failing tests**
+
+```bash
+git add tests/e2e/home.spec.ts
+git commit -m "test: add failing e2e tests for sponsors & partners home page section"
+```
+
+---
+
+### Task 2: Create sponsor/partner data module
+
+**Files:**
+- Create: `lib/sponsors.ts`
+
+- [ ] **Step 1: Create `lib/sponsors.ts`**
+
+```typescript
+import { getLogoUrl } from '@/lib/cdn';
+
+export interface Sponsor {
+    name: string;
+    logo: string;
+    website?: string;
+}
+
+export const goldSponsors: Sponsor[] = [
+    {
+        name: "Resilient Ventures",
+        logo: getLogoUrl("RV Color Horizontal.jpg"),
+        website: "https://resilient-ventures.com"
+    }
+];
+
+export const silverSponsors: Sponsor[] = [];
+
+export const bronzeSponsors: Sponsor[] = [];
+
+export const partners: Sponsor[] = [
+    {
+        name: "Mass Open Cloud",
+        logo: getLogoUrl("MOCwordmark_RGB_small.png"),
+        website: "https://massopen.cloud"
+    }
+];
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add lib/sponsors.ts
+git commit -m "feat: add sponsors/partners data module"
+```
+
+---
+
+### Task 3: Create the SponsorsPartners component
+
+**Files:**
+- Create: `components/sponsors-partners.tsx`
+
+- [ ] **Step 1: Create `components/sponsors-partners.tsx`**
+
+```tsx
+"use client"
+
+import React from 'react';
+import Image from 'next/image';
+import { motion } from 'framer-motion';
+import { goldSponsors, silverSponsors, bronzeSponsors, partners, Sponsor } from '@/lib/sponsors';
+
+const logoCard = (sponsor: Sponsor, width: string, height: string, index: number) => (
+    <motion.a
+        key={sponsor.name}
+        href={sponsor.website}
+        target="_blank"
+        rel="noopener noreferrer"
+        initial={{ opacity: 0, scale: 0.9 }}
+        whileInView={{ opacity: 1, scale: 1 }}
+        whileHover={{ scale: 1.05 }}
+        transition={{ duration: 0.4, delay: index * 0.1 }}
+        viewport={{ once: true }}
+        className="bg-white rounded-lg shadow-lg p-6 flex items-center justify-center"
+    >
+        <div className={`relative ${width} ${height}`}>
+            <Image src={sponsor.logo} alt={sponsor.name} fill className="object-contain" />
+        </div>
+    </motion.a>
+);
+
+const SponsorsPartners = () => {
+    const hasSponsors = goldSponsors.length > 0 || silverSponsors.length > 0 || bronzeSponsors.length > 0;
+    const hasPartners = partners.length > 0;
+
+    return (
+        <section className="py-20 bg-gray-50">
+            <div className="container mx-auto px-6">
+                <motion.div
+                    initial={{ opacity: 0, y: 20 }}
+                    whileInView={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.6 }}
+                    viewport={{ once: true }}
+                >
+                    <h2 className="text-4xl font-bold text-center mb-12 text-gray-900">
+                        Thank You to Our Sponsors &amp; Partners
+                    </h2>
+
+                    {goldSponsors.length > 0 && (
+                        <div className="mb-12">
+                            <h3 className="text-2xl font-bold text-center mb-8 text-yellow-600">Gold Sponsors</h3>
+                            <div className="flex flex-wrap justify-center gap-8">
+                                {goldSponsors.map((s, i) => logoCard(s, "w-64", "h-32", i))}
+                            </div>
+                        </div>
+                    )}
+
+                    {silverSponsors.length > 0 && (
+                        <div className="mb-12">
+                            <h3 className="text-2xl font-bold text-center mb-8 text-gray-400">Silver Sponsors</h3>
+                            <div className="flex flex-wrap justify-center gap-8">
+                                {silverSponsors.map((s, i) => logoCard(s, "w-48", "h-24", i))}
+                            </div>
+                        </div>
+                    )}
+
+                    {bronzeSponsors.length > 0 && (
+                        <div className="mb-12">
+                            <h3 className="text-2xl font-bold text-center mb-8 text-orange-600">Bronze Sponsors</h3>
+                            <div className="flex flex-wrap justify-center gap-8">
+                                {bronzeSponsors.map((s, i) => logoCard(s, "w-32", "h-16", i))}
+                            </div>
+                        </div>
+                    )}
+
+                    {hasSponsors && hasPartners && (
+                        <div className="border-t border-gray-200 my-12" />
+                    )}
+
+                    {hasPartners && (
+                        <div className="mb-12">
+                            <h3 className="text-2xl font-bold text-center mb-8 text-gray-600">Our Partners</h3>
+                            <div className="flex flex-wrap justify-center gap-8">
+                                {partners.map((s, i) => logoCard(s, "w-48", "h-24", i))}
+                            </div>
+                        </div>
+                    )}
+
+                    <div className="text-center mt-12">
+                        <a
+                            href="/#contact"
+                            className="inline-block border-2 border-[#AE2D24] text-[#AE2D24] px-8 py-3 rounded-lg font-semibold hover:bg-[#AE2D24] hover:text-white transition-colors duration-200"
+                        >
+                            Interested in sponsoring? Get in touch →
+                        </a>
+                    </div>
+                </motion.div>
+            </div>
+        </section>
+    );
+};
+
+export default SponsorsPartners;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add components/sponsors-partners.tsx
+git commit -m "feat: add SponsorsPartners component with tier hierarchy and CTA"
+```
+
+---
+
+### Task 4: Add SponsorsPartners to the home page
+
+**Files:**
+- Modify: `app/page.tsx`
+
+- [ ] **Step 1: Update `app/page.tsx`**
+
+Add the import and insert the component between `<Testimonials />` and `<ContactSection />`:
+
+```tsx
+import About, { CollectionCTA } from '@/components/about'
+import ContactSection from '@/components/contact'
+import GoFundMe from '@/components/gofundme'
+import Hero from '@/components/hero'
+import MediaCoverage from '@/components/media-coverage'
+import Nav from '@/components/nav'
+import Services from '@/components/services'
+import SponsorsPartners from '@/components/sponsors-partners'
+import Testimonials from '@/components/testimonials'
+import Works from '@/components/works'
+import { loadVideoMetadata } from '@/lib/load-metadata'
+import { getGoFundMeConfig } from '@/lib/feature-flags'
+import React from 'react'
+
+const page = () => {
+    const videoMetadata = loadVideoMetadata();
+    const goFundMeConfig = getGoFundMeConfig();
+
+    return (
+        <>
+            <div id="home"></div>
+            <Nav />
+            <Hero />
+            <CollectionCTA />
+            <Works videos={videoMetadata.videos} />
+            <About />
+            <Services />
+            {/* <Stats /> */}
+            {goFundMeConfig.enabled && goFundMeConfig.campaignId && (
+                <GoFundMe
+                    campaignId={goFundMeConfig.campaignId}
+                    useEmbedded={goFundMeConfig.useEmbedded}
+                    showTracker={goFundMeConfig.showTracker}
+                />
+            )}
+            <MediaCoverage />
+            <Testimonials />
+            <SponsorsPartners />
+            <ContactSection />
+        </>
+    )
+}
+
+export default page
+```
+
+- [ ] **Step 2: Run the e2e tests to confirm the home page tests pass**
+
+```bash
+npm test -- tests/e2e/home.spec.ts
+```
+
+Expected: ALL tests pass, including the two new ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/page.tsx
+git commit -m "feat: add SponsorsPartners section to home page"
+```
+
+---
+
+### Task 5: Remove sponsors/partners from Who We Are
+
+**Files:**
+- Modify: `components/who-we-are.tsx`
+
+- [ ] **Step 1: Remove `getLogoUrl` from the import**
+
+Change line 7 from:
+```typescript
+import { getBioImageUrl, getImageUrl, getLogoUrl } from '@/lib/cdn';
+```
+To:
+```typescript
+import { getBioImageUrl, getImageUrl } from '@/lib/cdn';
+```
+
+- [ ] **Step 2: Remove the `Sponsor` interface**
+
+Remove lines 30–34:
+```typescript
+interface Sponsor {
+    name: string;
+    logo: string;
+    website?: string;
+}
+```
+
+- [ ] **Step 3: Remove the sponsor/partner data arrays**
+
+Remove these lines from inside the `WhoWeAre` component body (currently around lines 151–169):
+```typescript
+    const goldSponsors: Sponsor[] = [
+        {
+            name: "Resilient Ventures",
+            logo: getLogoUrl("RV Color Horizontal.jpg"),
+            website: "https://resilient-ventures.com"
+        }
+    ];
+
+    const silverSponsors: Sponsor[] = [];
+
+    const bronzeSponsors: Sponsor[] = [];
+
+    const partners: Sponsor[] = [
+        {
+            name: "Mass Open Cloud",
+            logo: getLogoUrl("MOCwordmark_RGB_small.png"),
+            website: "https://massopen.cloud"
+        }
+    ];
+```
+
+- [ ] **Step 4: Remove the Sponsors section JSX**
+
+Remove the entire block (currently lines 421–519):
+```tsx
+            {/* Sponsors Section */}
+            {(goldSponsors.length > 0 || silverSponsors.length > 0 || bronzeSponsors.length > 0) && (
+                <section className="py-20 bg-gray-100">
+                    ...
+                </section>
+            )}
+```
+
+- [ ] **Step 5: Remove the Partners section JSX**
+
+Remove the entire block (currently lines 521–556):
+```tsx
+            {/* Partners Section */}
+            {partners.length > 0 && (
+                <section className="py-20 bg-white">
+                    ...
+                </section>
+            )}
+```
+
+- [ ] **Step 6: Run all e2e tests to confirm nothing broke**
+
+```bash
+npm test
+```
+
+Expected: ALL tests pass. In particular, `who-we-are.spec.ts` and `home.spec.ts` both pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/who-we-are.tsx
+git commit -m "refactor: remove sponsors/partners from Who We Are page (moved to home)"
+```

--- a/docs/superpowers/specs/2026-04-27-volunteers-storykeeping-collective-design.md
+++ b/docs/superpowers/specs/2026-04-27-volunteers-storykeeping-collective-design.md
@@ -1,0 +1,44 @@
+# Volunteers — Storykeeping Collective Listing
+
+**Date:** 2026-04-27
+**Branch:** feat/add-volunteers-to-who-we-are
+**File:** `components/who-we-are.tsx`
+
+## Goal
+
+Add a listing of Storykeeping Collective volunteers below the existing 4-photo collage in the Storykeeping Collective block on the Who We Are page. The listing uses the same card layout as the Strategic Advisory Board so the two sections share a consistent visual language.
+
+## Scope
+
+- Single file change: `components/who-we-are.tsx`
+- No new components, no new interfaces, no new state
+- No section reordering (deferred)
+
+## Data
+
+Add a `volunteerMembers: TeamMember[]` array inside the `WhoWeAre` component (same pattern as `teamMembers` and `boardMembers`). Populate with 3 placeholder entries:
+
+| Field  | Value |
+|--------|-------|
+| name   | "Volunteer Placeholder 1 / 2 / 3" |
+| title  | "Storykeeper" |
+| photo  | Existing project image via `getImageUrl(...)` — swapped for real photos later |
+| bio    | Short placeholder text describing the storykeeper role |
+| linkedin | omitted |
+
+## Layout
+
+Directly below the closing `</div>` of the 4-photo collage block (~line 342 in current file), insert:
+
+1. A subheading "Meet the Storykeepers" (same style as other subheadings)
+2. A responsive grid — `grid grid-cols-2 md:grid-cols-3 gap-6 max-w-5xl mx-auto mt-8` — rendering one `MemberCard` per volunteer
+
+Clicking any card opens the existing `BioModal` via the shared `selectedMember` state. No new modal logic needed.
+
+## What is NOT changing
+
+- Section order on the page
+- `TeamMember` interface
+- `MemberCard` component
+- `BioModal` component
+- `selectedMember` / `setSelectedMember` state

--- a/docs/superpowers/specs/2026-05-04-sponsors-partners-home-page-design.md
+++ b/docs/superpowers/specs/2026-05-04-sponsors-partners-home-page-design.md
@@ -1,0 +1,104 @@
+# Sponsors & Partners — Home Page Section Design
+
+**Date:** 2026-05-04
+**Branch:** feat/add-volunteers-to-who-we-are
+
+## Goal
+
+Move the sponsors and partners display from the Who We Are page to the home page. Add tier-based visual hierarchy, framer-motion animations, and a "Become a Sponsor" CTA. Remove the section from Who We Are entirely.
+
+## Files
+
+| Action | Path |
+|--------|------|
+| Create | `lib/sponsors.ts` |
+| Create | `components/sponsors-partners.tsx` |
+| Modify | `app/page.tsx` |
+| Modify | `components/who-we-are.tsx` |
+
+## Data (`lib/sponsors.ts`)
+
+Export a `Sponsor` interface and four named arrays:
+
+```ts
+export interface Sponsor {
+  name: string;
+  logo: string;
+  website?: string;
+}
+
+export const goldSponsors: Sponsor[]
+export const silverSponsors: Sponsor[]
+export const bronzeSponsors: Sponsor[]
+export const partners: Sponsor[]
+```
+
+Pre-populate from current `who-we-are.tsx` data:
+- `goldSponsors`: Resilient Ventures (`getLogoUrl("RV Color Horizontal.jpg")`, `https://resilient-ventures.com`)
+- `silverSponsors`: `[]`
+- `bronzeSponsors`: `[]`
+- `partners`: Mass Open Cloud (`getLogoUrl("MOCwordmark_RGB_small.png")`, `https://massopen.cloud`)
+
+## Component (`components/sponsors-partners.tsx`)
+
+### Section wrapper
+- `"use client"` (needs framer-motion)
+- `<section className="py-20 bg-gray-50">`
+- `<div className="container mx-auto px-6">`
+- `whileInView` fade-in on the whole section (`initial={{ opacity: 0, y: 20 }}`, `transition={{ duration: 0.6 }}`, `viewport={{ once: true }}`)
+
+### Heading
+```
+Thank You to Our Sponsors & Partners
+```
+- `text-4xl font-bold text-center mb-12 text-gray-900`
+
+### Sponsor tiers (Gold → Silver → Bronze)
+Each tier only renders when its array is non-empty. Per tier:
+- Tier label centered above logos, styled in tier color:
+  - Gold: `text-yellow-600`
+  - Silver: `text-gray-400`
+  - Bronze: `text-orange-600`
+- Logo cards: white background (`bg-white`), rounded-lg, shadow-lg, clickable `<a>` linking to `sponsor.website` (target `_blank`)
+- Logo image sizes by tier:
+  - Gold: `w-64 h-32`
+  - Silver: `w-48 h-24`
+  - Bronze: `w-32 h-16`
+- Logos use Next.js `<Image>` with `fill` and `object-contain`
+- `whileInView` staggered animation per logo: `initial={{ opacity: 0, scale: 0.9 }}`, `animate={{ opacity: 1, scale: 1 }}`, delay increments by `index * 0.1`
+- `whileHover={{ scale: 1.05 }}`
+- Cards centered horizontally with `flex flex-wrap justify-center gap-8`
+
+### Divider
+`<div className="border-t border-gray-200 my-12" />` — only rendered when both sponsors and partners are present.
+
+### Partners
+Only renders when `partners.length > 0`. Layout identical to a sponsor tier but:
+- Label: "Our Partners" in `text-gray-600`
+- Card size: `w-48 h-24` (same as Silver)
+
+### Become a Sponsor CTA
+Always rendered at the bottom:
+```tsx
+<div className="text-center mt-12">
+  <a
+    href="/#contact"
+    className="inline-block border-2 border-[#AE2D24] text-[#AE2D24] px-8 py-3 rounded-lg font-semibold hover:bg-[#AE2D24] hover:text-white transition-colors duration-200"
+  >
+    Interested in sponsoring? Get in touch →
+  </a>
+</div>
+```
+
+## Home Page (`app/page.tsx`)
+
+Add import and insert `<SponsorsPartners />` between `<Testimonials />` and `<ContactSection />`.
+
+## Who We Are (`components/who-we-are.tsx`)
+
+Remove:
+- `interface Sponsor` declaration
+- `goldSponsors`, `silverSponsors`, `bronzeSponsors`, `partners` arrays
+- The Sponsors `<section>` block (conditional on sponsor arrays)
+- The Partners `<section>` block (conditional on partners array)
+- `getLogoUrl` from the import line (confirmed only used for sponsor/partner data)

--- a/lib/sponsors.ts
+++ b/lib/sponsors.ts
@@ -1,0 +1,27 @@
+import { getLogoUrl } from '@/lib/cdn';
+
+export interface Sponsor {
+    name: string;
+    logo: string;
+    website?: string;
+}
+
+export const goldSponsors: Sponsor[] = [
+    {
+        name: "Resilient Ventures",
+        logo: getLogoUrl("RV Color Horizontal.jpg"),
+        website: "https://resilient-ventures.com"
+    }
+];
+
+export const silverSponsors: Sponsor[] = [];
+
+export const bronzeSponsors: Sponsor[] = [];
+
+export const partners: Sponsor[] = [
+    {
+        name: "Mass Open Cloud",
+        logo: getLogoUrl("MOCwordmark_RGB_small.png"),
+        website: "https://massopen.cloud"
+    }
+];

--- a/metadata/videos.yaml
+++ b/metadata/videos.yaml
@@ -200,7 +200,7 @@ videos:
     createdDate: "2026-02-09T12:00:00Z"
     videoUrl: "https://www.youtube.com/watch?v=Uea17sw8xW0"
     podcastUrl: "https://open.spotify.com/episode/5MJzmnOw8C2sy0yw3URK5k?si=UcYW5o3eQf66FOUBLU7A5g"
-    featured: true
+    featured: false
     historicalContext:
       - location:
           name: "Raleigh, North Carolina"
@@ -242,7 +242,7 @@ videos:
     createdDate: "2026-02-18T12:00:00Z"
     videoUrl: "https://www.youtube.com/watch?v=mBngYEV7_cc"
     podcastUrl: "https://open.spotify.com/episode/4o9wuMJ0dLzBMHydGxRlGh?si=TLiqo-3bTKKKfNK966uqRw"
-    featured: true
+    featured: false
     historicalContext:
       - year: 1980
         location:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "leaflet": "^1.9.4",
         "lucide-react": "^0.474.0",
         "next": "^15.1.9",
-        "next-auth": "^5.0.0-beta.25",
+        "next-auth": "^4.24.14",
         "next-cloudinary": "^6.16.0",
         "playwright": "^1.58.0",
         "react": "^19.0.0",
@@ -64,33 +64,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@auth/core": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.41.0.tgz",
-      "integrity": "sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@panva/hkdf": "^1.2.1",
-        "jose": "^6.0.6",
-        "oauth4webapi": "^3.3.0",
-        "preact": "10.24.3",
-        "preact-render-to-string": "6.5.11"
-      },
-      "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "nodemailer": "^6.8.0"
-      },
-      "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
-          "optional": true
-        },
-        "nodemailer": {
-          "optional": true
-        }
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cloudinary-util/types": {
@@ -2443,6 +2423,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4328,9 +4317,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -4647,9 +4636,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -4724,25 +4713,30 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "5.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-5.0.0-beta.30.tgz",
-      "integrity": "sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==",
+      "version": "4.24.14",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.14.tgz",
+      "integrity": "sha512-YRz6xFDXKUwiXSMMChbrBEWyFktZ1qZXEgeSHQQ3nsy08B4c/xLk6REeutRsIFwkjY/1+ShHnu07DN3JeJguig==",
       "license": "ISC",
       "dependencies": {
-        "@auth/core": "0.41.0"
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
       },
       "peerDependencies": {
-        "@simplewebauthn/browser": "^9.0.1",
-        "@simplewebauthn/server": "^9.0.2",
-        "next": "^14.0.0-0 || ^15.0.0 || ^16.0.0",
+        "@auth/core": "0.34.3",
+        "next": "^12.2.5 || ^13 || ^14 || ^15 || ^16",
         "nodemailer": "^7.0.7",
-        "react": "^18.2.0 || ^19.0.0"
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
       },
       "peerDependenciesMeta": {
-        "@simplewebauthn/browser": {
-          "optional": true
-        },
-        "@simplewebauthn/server": {
+        "@auth/core": {
           "optional": true
         },
         "nodemailer": {
@@ -4751,9 +4745,9 @@
       }
     },
     "node_modules/next-cloudinary": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/next-cloudinary/-/next-cloudinary-6.16.0.tgz",
-      "integrity": "sha512-gbw/A1aBHJBC2thm4/veI77IkmbAQXuRUj8kNEuxf1zgjGkUWkShho/cXS4VsFhnHuDieqb30gMjZnZdBDrQ/Q==",
+      "version": "6.17.5",
+      "resolved": "https://registry.npmjs.org/next-cloudinary/-/next-cloudinary-6.17.5.tgz",
+      "integrity": "sha512-YIyIWw5Ds30f4rnED+E9ssLUd94FOPTtbkO2KUvOcw9z4irOEIpb1goxMxbn2EUBnIGQOd6uUf1gFizjME7pMg==",
       "license": "MIT",
       "dependencies": {
         "@cloudinary-util/types": "1.5.10",
@@ -4802,14 +4796,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/oauth4webapi": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.3.tgz",
-      "integrity": "sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4939,6 +4930,51 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oidc-token-hash": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
+      "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/optionator": {
@@ -5155,9 +5191,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-      "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -5174,7 +5210,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -5298,9 +5334,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.24.3",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
-      "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -5308,10 +5344,13 @@
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "6.5.11",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-6.5.11.tgz",
-      "integrity": "sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
       "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -5325,6 +5364,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6520,6 +6565,16 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6633,6 +6688,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "leaflet": "^1.9.4",
     "lucide-react": "^0.474.0",
     "next": "^15.1.9",
-    "next-auth": "^5.0.0-beta.25",
+    "next-auth": "^4.24.14",
     "next-cloudinary": "^6.16.0",
     "playwright": "^1.58.0",
     "react": "^19.0.0",

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -23,13 +23,13 @@ test.describe('Home Page', () => {
     await expect(page.locator('body')).toBeVisible();
   });
 
-  test('shows sponsors and partners section', async ({ page }) => {
+  test('should show sponsors and partners section', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('text=Thank You to Our Sponsors & Partners')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Sponsors & Partners/i })).toBeVisible();
   });
 
-  test('shows become a sponsor CTA', async ({ page }) => {
+  test('should show become a sponsor CTA', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('text=Interested in sponsoring?')).toBeVisible();
+    await expect(page.getByText('Interested in sponsoring?')).toBeVisible();
   });
 });

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -22,4 +22,14 @@ test.describe('Home Page', () => {
     await page.setViewportSize({ width: 1920, height: 1080 });
     await expect(page.locator('body')).toBeVisible();
   });
+
+  test('shows sponsors and partners section', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('text=Thank You to Our Sponsors & Partners')).toBeVisible();
+  });
+
+  test('shows become a sponsor CTA', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('text=Interested in sponsoring?')).toBeVisible();
+  });
 });

--- a/tests/e2e/who-we-are.spec.ts
+++ b/tests/e2e/who-we-are.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Who We Are page', () => {
+  test('shows Storykeeping Collective volunteer cards', async ({ page }) => {
+    await page.goto('/who-we-are');
+
+    const section = page.locator('text=Meet the Storykeepers');
+    await expect(section).toBeVisible();
+  });
+
+  test('volunteer card opens bio modal on click', async ({ page }) => {
+    await page.goto('/who-we-are');
+
+    await page.locator('text=Volunteer Placeholder 1').first().click();
+
+    const modal = page.locator('text=A dedicated volunteer');
+    await expect(modal).toBeVisible();
+  });
+});

--- a/tests/e2e/who-we-are.spec.ts
+++ b/tests/e2e/who-we-are.spec.ts
@@ -11,9 +11,14 @@ test.describe('Who We Are page', () => {
   test('volunteer card opens bio modal on click', async ({ page }) => {
     await page.goto('/who-we-are');
 
-    await page.locator('text=Volunteer Placeholder 1').first().click();
+    // Scroll to bottom to bring Storykeeping Collective into view and trigger framer-motion
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
 
-    const modal = page.locator('text=A dedicated volunteer');
+    const card = page.locator('.cursor-pointer').filter({ hasText: 'Demethria Ramseur' }).first();
+    await expect(card).toBeVisible({ timeout: 5000 });
+    await card.click();
+
+    const modal = page.locator('text=Agile practitioner');
     await expect(modal).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- **Storykeeping Collective volunteers** — adds a volunteer card grid (Demethria Ramseur, Thoan Freckleton, Kimla Lee) below the Storykeeping Collective photo collage on the Who We Are page, styled consistently with the Strategic Advisory Board cards
- **Sponsors & Partners section on home page** — moves sponsors/partners from Who We Are to the home page with tier-differentiated logo cards (Gold/Silver/Bronze/Partners), framer-motion animations, and a mailto CTA pre-filled for sponsorship inquiries; removes the sections from Who We Are entirely
- **Service cards hidden** — Centralized Repository, AI Metadata Extraction, Content Enrichment, AI Annotation, Generative AI Enhancement, and Searchable Index cards commented out; section now shows featured video only
- **Merge upstream** — includes upstream podcast URL additions and next-auth stable downgrade

## Test Plan

- [ ] All 9 e2e tests pass (`npm test`)
- [ ] Who We Are page: volunteer cards visible below Storykeeping Collective collage; clicking a card opens bio modal
- [ ] Home page: Sponsors & Partners section visible between Testimonials and Contact; sponsorship CTA opens pre-filled mailto
- [ ] Who We Are page: no sponsors or partners sections present
- [ ] Work Of The Project section: only the featured video renders, no service cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)